### PR TITLE
Change version back to v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnfoldStats"
 uuid = "96fd419a-8306-4ce8-ba5b-cd907cb7647c"
 authors = ["Judith Schepers", "Benedikt V. Ehinger"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"


### PR DESCRIPTION
I wanted to change the initial version for the package registration to v0.1.0 as suggested by the JuliaRegistrator bot. This lead to some unexpected problems with CI, therefore I'm changing it back to test whether this was causing the problem.