### PR TITLE
Enable stable documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags: ['*']
+    tags: '*'
   pull_request:
   workflow_dispatch:
 concurrency:
@@ -58,6 +58,7 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest


### PR DESCRIPTION
I adapted the CI GitHub workflow (which contains the deployment of the docs) to use a key with write access which is necessary to have stable + versioned documentation.